### PR TITLE
WebKit.framework inclusion

### DIFF
--- a/help/ios/getting-started/dev-qs.md
+++ b/help/ios/getting-started/dev-qs.md
@@ -73,6 +73,7 @@ To download the SDK:
 
       * **iOS App Targets**
         * `SystemConfiguration.framework`
+        * `Webkit.framework`
         * `libsqlite3.0.tbd`
         * `AdobeMobileLibrary.a`
 


### PR DESCRIPTION
iOS 4.18.8 version requires WebKit.framework to be included in the application